### PR TITLE
Typo

### DIFF
--- a/Italian/main/SecurityCenter.apk/res/values-it/strings.xml
+++ b/Italian/main/SecurityCenter.apk/res/values-it/strings.xml
@@ -1263,7 +1263,7 @@ dall'operatore"</string>
      <string name="menu_summary_networkassistants_3">Hai abbastanza traffico dati</string>
      <string name="menu_summary_networkassistants_4">Sei a corto di traffico dati</string>
      <string name="menu_summary_power_manager">"Il risparmio energetico ti fornirà più tempo tra una ricarica e l'altra"</string>
-     <string name="menu_summary_power_manager_1">La batteria è completamente carica</string>
+     <string name="menu_summary_power_manager_1">La batteria è carica</string>
      <string name="menu_summary_power_manager_2">%s rimanenti</string>
      <string name="menu_summary_power_manager_3">Collega il caricabatterie</string>
      <string name="menu_summary_power_manager_4">%s al termine</string>


### PR DESCRIPTION
Traduzione troppo lunga (fuori schermo)